### PR TITLE
fix: fix dependabot[bot] id

### DIFF
--- a/.github/workflows/multi_approvers.yaml
+++ b/.github/workflows/multi_approvers.yaml
@@ -34,12 +34,12 @@ jobs:
         with:
           team: 'googlers'
           token: '${{ secrets.MULTI_APPROVERS_TOKEN }}'
-          user-id-allowlist: '25180681,55107282,122572305,78513119,27347476,70984784,44816363'
+          user-id-allowlist: '25180681,55107282,122572305,78513119,49699333,70984784,44816363'
           # username to ID mapping (https://api.github.com/users/{username}):
           #   renovate-bot: 25180681
           #   release-please[bot]: 55107282
           #   cloud-java-bot: 122572305
           #   gcf-owl-bot[bot]: 78513119
-          #   dependabot[bot]: 27347476
+          #   dependabot[bot]: 49699333
           #   yoshi-code-bot: 70984784
           #   yoshi-automation: 44816363


### PR DESCRIPTION
The id should come from https://api.github.com/users/dependabot[bot] rather than https://api.github.com/users/dependabot.